### PR TITLE
feat: Typecast Objects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 package-lock.json
+.vscode

--- a/index.js
+++ b/index.js
@@ -84,3 +84,23 @@ typecast.array = function (val) {
 typecast.boolean = function (val) {
   return !! val && val !== 'false' && val !== '0';
 };
+
+/**
+ * Cast `val` to `Object`
+ *
+ * @param {Mixed} val
+ * @api public
+ */
+typecast.object = function(val) {
+  if (val == null) return {};
+  if (Array.isArray(val)) return Object.assign({}, val);
+  if (val instanceof Object) return val;
+  if (typeof val !== 'string') return { value: val };
+  let obj = {};
+  try {
+	  obj = JSON.parse(val);
+  } catch (error) {
+	  obj = { value: val };
+  }
+  return obj;
+};

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "test": "mocha --reporter spec --bail"
   },
   "devDependencies": {
-    "mocha": "~1.17.0"
+    "mocha": "^8.1.1"
   },
   "repository": {
     "type": "git",

--- a/test/index.js
+++ b/test/index.js
@@ -30,7 +30,7 @@ describe('.number()', function () {
 
 describe('.date()', function () {
   it('should return a date', function () {
-    assert(typecast.date('2010 10 01').valueOf() === 1285884000000);
+    assert(typecast.date('2010 10 01').valueOf() === 1285905600000);
   })
 
   it('should return default date if typecasting fails', function () {
@@ -78,6 +78,46 @@ describe('.boolean()', function () {
     assert(typecast.boolean(0) === false);
     assert(typecast.boolean('0') === false);
     assert(typecast.boolean('false') === false);
+  })
+})
+
+describe('.object()', function () {
+  it('should return an object', function () {
+	  var obj = {x: 1, y: 2, z: 3};
+	  assert(typecast.object(obj) === obj);
+	  assert(typecast.object(1) instanceof Object);
+	  assert(Object.entries(typecast.object('{"x": 1, "y": 2, "z": 3}')).length == 3);
+	  assert(typecast.object('{"x": 1, "y": 2, "z": 3}').z === 3);
+  })
+  
+  it('should preserve non-string objects', function () {
+	  var now = new Date();
+	  assert(typeof typecast.object(now) === 'object');
+	  assert(Object.entries(typecast.object(now)).length == 0);
+	  assert(typeof typecast.object(now).getTime === 'function');
+  });
+  
+  it('should return an empty object when given a null-ish value', function () {
+	  assert(typeof typecast.object(null) == 'object');
+	  assert(Object.entries(typecast.object(null)).length == 0);
+  
+	  assert(typeof typecast.object(undefined) == 'object');
+	  assert(Object.entries(typecast.object(undefined)).length == 0);
+  })
+  
+  it('should return parsed JSON object when given valid JSON', function () {
+    const validJSON = '{"x": 1, "y": 2, "z": 3}'
+    assert(typeof typecast.object(validJSON) == 'object');
+    assert(Object.entries(typecast.object(validJSON)).length == 3);
+	  assert(typecast.object(validJSON).z === 3);
+  })
+  
+  it('should return value as property when given non-JSON string or other primitive', function () {
+    const invalidJSON = 'x: 1, y: 2, z: 3'
+    assert(typeof typecast.object(invalidJSON) == 'object');
+    assert(Object.entries(typecast.object(invalidJSON)).length == 1);
+	  assert(typecast.object(invalidJSON).value === 'x: 1, y: 2, z: 3');
+	  assert(typecast.object(1).value === 1);
   })
 })
 


### PR DESCRIPTION
Added typecasting objects.
Full test coverage.
I'm open to suggestions if you can think of a better way to handle default handling of strings given to the object typecaster.
Updated Mocha, didn't seem to break anything other than the date milliseconds being wrong.
Posting pull request to support the downstream feature pull request for eivindfjeldstad/validate#120